### PR TITLE
Speedup `deeplearndata_training` process

### DIFF
--- a/src/deeplearn.c
+++ b/src/deeplearn.c
@@ -108,12 +108,23 @@ int deeplearn_init(deeplearn * learner,
     /* no training/test data yet */
     learner->data = 0;
     learner->data_samples = 0;
+    learner->indexed_data = 0;
+    learner->indexed_data_samples = 0;
+
     learner->training_data = 0;
     learner->training_data_samples = 0;
+    learner->indexed_training_data = 0;
+    learner->indexed_training_data_samples = 0;
+
     learner->training_data_labeled = 0;
     learner->training_data_labeled_samples = 0;
+    learner->indexed_training_data_labeled = 0;
+    learner->indexed_training_data_labeled_samples = 0;
+
     learner->test_data = 0;
     learner->test_data_samples = 0;
+    learner->indexed_test_data = 0;
+    learner->indexed_test_data_samples = 0;
 
     learner->no_of_input_fields = 0;
     learner->field_length = 0;

--- a/src/deeplearn.h
+++ b/src/deeplearn.h
@@ -39,7 +39,7 @@
 #include "encoding.h"
 #include "deeplearn_conv.h"
 
-typedef struct {
+struct deeplearndata {
     float * inputs;
     char ** inputs_text;
     float * outputs;
@@ -47,13 +47,15 @@ typedef struct {
     unsigned int labeled;
     struct deeplearndata * prev;
     struct deeplearndata * next;
-} deeplearndata;
+};
+typedef struct deeplearndata deeplearndata;
 
-typedef struct {
+struct deeplearndata_meta {
     deeplearndata * sample;
     struct deeplearndata_meta * prev;
     struct deeplearndata_meta * next;
-} deeplearndata_meta;
+};
+typedef struct deeplearndata_meta deeplearndata_meta;
 
 struct deepl {
     bp * net;
@@ -68,12 +70,23 @@ struct deepl {
 
     deeplearndata * data;
     int data_samples;
+    deeplearndata ** indexed_data;
+    int indexed_data_samples;
+
     deeplearndata_meta * training_data;
     int training_data_samples;
+    deeplearndata_meta ** indexed_training_data;
+    int indexed_training_data_samples;
+
     deeplearndata_meta * training_data_labeled;
     int training_data_labeled_samples;
+    deeplearndata_meta ** indexed_training_data_labeled;
+    int indexed_training_data_labeled_samples;
+
     deeplearndata_meta * test_data;
     int test_data_samples;
+    deeplearndata_meta ** indexed_test_data;
+    int indexed_test_data_samples;
 
     float * input_range_min;
     float * input_range_max;

--- a/src/deeplearndata.h
+++ b/src/deeplearndata.h
@@ -51,6 +51,16 @@ int deeplearndata_add(deeplearndata ** datalist,
                       float input_range_max[],
                       float output_range_min[],
                       float output_range_max[]);
+int deeplearndata_index_data(
+        deeplearndata * list,
+        int samples,
+        deeplearndata *** indexed_list,
+        int* indexed_samples);
+int deeplearndata_index_meta(
+        deeplearndata_meta * list,
+        int samples,
+        deeplearndata_meta *** indexed_list,
+        int* indexed_samples);
 deeplearndata * deeplearndata_get(deeplearn * learner, int index);
 deeplearndata * deeplearndata_get_training(deeplearn * learner, int index);
 deeplearndata * deeplearndata_get_training_labeled(deeplearn * learner, int index);

--- a/unittests/tests_data.c
+++ b/unittests/tests_data.c
@@ -74,6 +74,14 @@ static void test_data_add()
         free(outputs);
     }
     assert(learner.data_samples == 5);
+    assert(learner.indexed_data_samples == 0);
+
+    assert(deeplearndata_index_data(
+            learner.data,
+            learner.data_samples,
+            &learner.indexed_data,
+            &learner.indexed_data_samples) == 0);
+    assert(learner.indexed_data_samples == 5);
 
     /* check that the samples have the expected values.
        Note that the sequence is reversed */
@@ -151,14 +159,28 @@ static void test_data_training_test()
         free(outputs);
     }
     assert(learner.data_samples == 100);
+    assert(learner.indexed_data_samples == 0);
+
+    assert(deeplearndata_index_data(
+            learner.data,
+            learner.data_samples,
+            &learner.indexed_data,
+            &learner.indexed_data_samples) == 0);
+    assert(learner.indexed_data_samples == 100);
 
     assert(learner.training_data_samples == 0);
     assert(learner.training_data_labeled_samples == 0);
     assert(learner.test_data_samples == 0);
+    assert(learner.indexed_training_data_samples == 0);
+    assert(learner.indexed_training_data_labeled_samples == 0);
+    assert(learner.indexed_test_data_samples == 0);
     assert(deeplearndata_create_datasets(&learner, 20) == 0);
     assert(learner.training_data_samples == 80);
     assert(learner.training_data_labeled_samples == 77);
     assert(learner.test_data_samples == 20);
+    assert(learner.indexed_training_data_samples == 80);
+    assert(learner.indexed_training_data_labeled_samples == 77);
+    assert(learner.indexed_test_data_samples == 20);
 
     /* check that all test samples are labeled */
     for (int i = 0; i < learner.test_data_samples; i++) {

--- a/unittests/tests_deeplearn.c
+++ b/unittests/tests_deeplearn.c
@@ -327,8 +327,11 @@ static void test_deeplearn_csv_with_text()
                            &random_seed);
 
     assert(learner.training_data_samples == 6);
+    assert(learner.indexed_training_data_samples == 6);
     assert(learner.training_data_labeled_samples == 6);
+    assert(learner.indexed_training_data_labeled_samples == 6);
     assert(learner.test_data_samples == 2);
+    assert(learner.indexed_test_data_samples == 2);
     assert(learner.net->NoOfInputs == 2 + (5*CHAR_BITS));
     assert(learner.no_of_input_fields == 3);
 
@@ -390,8 +393,11 @@ static void test_deeplearn_csv_numeric()
                            &random_seed);
 
     assert(learner.training_data_samples == 6);
+    assert(learner.indexed_training_data_samples == 6);
     assert(learner.training_data_labeled_samples == 6);
+    assert(learner.indexed_training_data_labeled_samples == 6);
     assert(learner.test_data_samples == 2);
+    assert(learner.indexed_test_data_samples == 2);
     assert(learner.net->NoOfInputs == 3);
     assert(learner.no_of_input_fields == 3);
 


### PR DESCRIPTION
Index `data`, `training_data`, `training_data_labeled`, and
`test_data` in `deepl` struct to allow faster direct access.

Performance gain: x2 on wine example, much more when data has many
(millions) of lines.