### PR TITLE
Fixed conditions

### DIFF
--- a/src/deeplearn.c
+++ b/src/deeplearn.c
@@ -422,20 +422,18 @@ void deeplearn_free(deeplearn * learner)
     while (sample != 0) {
         prev_sample = sample;
         sample = (deeplearndata *)sample->next;
-        if (prev_sample != 0) {
-            if (prev_sample->inputs_text != 0) {
-                /* clear any input text strings */
-                COUNTDOWN(i, learner->no_of_input_fields) {
-                    if (prev_sample->inputs_text[i] != 0)
-                        free(prev_sample->inputs_text[i]);
-                }
-                free(prev_sample->inputs_text);
+        if (prev_sample->inputs_text != 0) {
+            /* clear any input text strings */
+            COUNTDOWN(i, learner->no_of_input_fields) {
+                if (prev_sample->inputs_text[i] != 0)
+                    free(prev_sample->inputs_text[i]);
             }
-            /* clear numerical fields */
-            free(prev_sample->inputs);
-            free(prev_sample->outputs);
-            free(prev_sample);
+            free(prev_sample->inputs_text);
         }
+        /* clear numerical fields */
+        free(prev_sample->inputs);
+        free(prev_sample->outputs);
+        free(prev_sample);
     }
 
     /* free training samples */

--- a/src/deeplearn_images.c
+++ b/src/deeplearn_images.c
@@ -347,8 +347,6 @@ int deeplearn_load_training_images(char * images_directory,
 
                     COUNTDOWN(s, extra_synthetic_images) {
                         UCHARALLOC(img2, width*height);
-                        if (!img2)
-                            return -6;
                         if (img2 != NULL) {
                             /* scaling factor 0.5 -> 1.0 */
                             scale = 0.5f +
@@ -370,6 +368,8 @@ int deeplearn_load_training_images(char * images_directory,
                                         width, height, 1, img2);
                             (*images)[no_of_images] = img2;
                         }
+                        else
+                            return -6;
 
                         CHARALLOC(classification, 256);
                         if (!classification)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warnings, found using PVS-Studio:
libdeep/src/deeplearn.c     425     warn    V547 Expression 'prev_sample != 0' is always true.
libdeep/src/deeplearn_images.c      352     warn    V547 Expression 'img2 != NULL' is always true.