### PR TITLE
New static analyser issues

### DIFF
--- a/src/backprop.c
+++ b/src/backprop.c
@@ -1108,7 +1108,12 @@ int bp_classifications_to_numbers(int no_of_instances,
             CHARALLOC(unique_classification[unique_ctr],
                       1+strlen(instance_classification[i]));
             if (!unique_classification[unique_ctr])
+            {
+                COUNTDOWN(i, unique_ctr)
+                    free(unique_classification[i]);
+                free(unique_classification);
                 return -2;
+            }
 
             sprintf(unique_classification[unique_ctr],
                     "%s", instance_classification[i]);

--- a/src/deeplearn_images.c
+++ b/src/deeplearn_images.c
@@ -464,7 +464,6 @@ int image_resize(unsigned char img[],
             int n = (y*result_width + x) * result_depth;
             int n_orig = (y_orig*image_width + x_orig) * image_depth;
             if (result_depth == 1) {
-                result[n] = 0;
                 int sum = 0;
                 COUNTDOWN(d, image_depth)
                     sum += (int)img[n_orig + d];


### PR DESCRIPTION
I like your project and I'm exploring it as part of the competition the Pinguem.ru competition on finding errors in open source projects. New warnings, found using PVS-Studio:
libdeep/src/deeplearn_images.c	471	warn	V519 The 'result[n]' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 467, 471.
libdeep/src/backprop.c	1111	err	V773 The function was exited without releasing the 'unique_classification' pointer. A memory leak is possible.